### PR TITLE
Resolved min date on create event

### DIFF
--- a/frontend/src/pages/CreateEvent.tsx
+++ b/frontend/src/pages/CreateEvent.tsx
@@ -117,6 +117,7 @@ const CreateEvent: React.FC = () => {
                     className="input-field pl-10"
                     value={formData.date}
                     onChange={handleChange}
+                    min={new Date().toISOString().split("T")[0]} 
                   />
                 </div>
               </div>


### PR DESCRIPTION
When creating an event, the minimum date is the present date. No past dates can be selected.
Ticket #26 